### PR TITLE
changed WETH9.sol solidity version and ETH transfer

### DIFF
--- a/contracts/WETH9.sol
+++ b/contracts/WETH9.sol
@@ -19,7 +19,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity ^0.7.0;
+pragma solidity ^0.8.0;
 
 contract WETH9 {
     string public name     = "Wrapped Ether";
@@ -46,7 +46,7 @@ contract WETH9 {
     function withdraw(uint wad) public {
         require(balanceOf[msg.sender] >= wad);
         balanceOf[msg.sender] -= wad;
-        msg.sender.transfer(wad);
+        payable(msg.sender).transfer(wad);
         emit Withdrawal(msg.sender, wad);
     }
 
@@ -70,7 +70,7 @@ contract WETH9 {
     {
         require(balanceOf[src] >= wad);
 
-        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
+        if (src != msg.sender && allowance[src][msg.sender] != type(uint256).max) {
             require(allowance[src][msg.sender] >= wad);
             allowance[src][msg.sender] -= wad;
         }


### PR DESCRIPTION
When importing WETH9.sol from other contracts, it won't compile due to inconsistent Solidity versions. All the other challenge contracts use v0.8 yet WETH9 uses v0.7. I upgraded WETH9 to v0.8.0 and made the corresponding changes to make sure it compiles.  