### PR TITLE
A tiny puppet change

### DIFF
--- a/test/puppet/puppet.challenge.js
+++ b/test/puppet/puppet.challenge.js
@@ -114,6 +114,6 @@ describe('[Challenge] Puppet', function () {
         ).to.be.eq('0');
         expect(
             await this.token.balanceOf(attacker.address)
-        ).to.be.gt(POOL_INITIAL_TOKEN_BALANCE);
+        ).to.be.gte(POOL_INITIAL_TOKEN_BALANCE);
     });
 });


### PR DESCRIPTION
The puppet challenge expects the attackers balance to be greater than the initial pool balance.
https://github.com/tinchoabbate/damn-vulnerable-defi/blob/82b6049452c387235ee0b452b0de9f3dca88c072/test/puppet/puppet.challenge.js#L117
This is unlike puppet-v2 where the correct test is made.
https://github.com/tinchoabbate/damn-vulnerable-defi/blob/82b6049452c387235ee0b452b0de9f3dca88c072/test/puppet-v2/puppet-v2.challenge.js#L97
This leads to a more convoluted solution requiring either the attacker swap tokens more than once or only sell some of his tokens.
