### PR TITLE
[Climber] Fix logic bug for the schedule delay not being considered

### DIFF
--- a/contracts/climber/ClimberTimelock.sol
+++ b/contracts/climber/ClimberTimelock.sol
@@ -53,10 +53,12 @@ contract ClimberTimelock is AccessControl {
         
         if(op.executed) {
             return OperationState.Executed;
-        } else if(op.readyAtTimestamp >= block.timestamp) {
-            return OperationState.ReadyForExecution;
         } else if(op.readyAtTimestamp > 0) {
-            return OperationState.Scheduled;
+            if(block.timestamp >= op.readyAtTimestamp) {
+                return OperationState.ReadyForExecution;
+            } else {
+                return OperationState.Scheduled;
+            }
         } else {
             return OperationState.Unknown;
         }


### PR DESCRIPTION
Hi tincho !
I'm currently delving into the smart contract security world and your work on the [damn-vulnerable-defi](https://github.com/tinchoabbate/damn-vulnerable-defi) challenges has been a immense source of knowledge for me to learn about those exploits so thanks a lot for that !

I recently completed the [Climber challenge](https://github.com/tinchoabbate/damn-vulnerable-defi/blob/master/contracts/climber/ClimberTimelock.sol) and I was wondering how the `ClimberTimelock` let me execute immediately after calling `schedule` since there should be a 1 hour delay and I did not change it through the `updateDelay` function.

I figured there is a little logic bug in the `getOperationState` function : it should check if the `block.timestamp` is >= to the `op.readyAtTimestamp`, not the other way around. 

This effectively affects the resolution of this challenge :
<details> 
  <summary>Spoiler</summary>
I solved the challenge by granting my contract the "proposer" role to be able to schedule any transaction from the `ClimberTimelock` contract (full solution <a href="https://github.com/Krow10/damn-vulnerable-defi/blob/master/test/climber/climber.challenge.js">here</a>).
  When first calling `execute` to set the role, there is now an additional step of calling `updateDelay` first to set the schedule delay to zero to be able to finish the `execute` transaction (or else it will simply revert). 
</details>

I didn't change the challenge setup but I could also include tests for ensuring the delay is being considered if needed.

Thanks for reviewing this !