### PR TITLE
Unstoppable: invalidate a trivial (unintended) solution

### DIFF
--- a/test/unstoppable/Unstoppable.t.sol
+++ b/test/unstoppable/Unstoppable.t.sol
@@ -98,6 +98,9 @@ contract UnstoppableChallenge is Test {
      * CHECKS SUCCESS CONDITIONS - DO NOT TOUCH
      */
     function _isSolved() private {
+       // Trivial solution: player advanced time beyond the vault's grace period
+       assertLt(block.timestamp, vault.end(), "Vault's grace period has ended");
+
         // Flashloan check must fail
         vm.prank(deployer);
         vm.expectEmit();

--- a/test/unstoppable/Unstoppable.t.sol
+++ b/test/unstoppable/Unstoppable.t.sol
@@ -98,7 +98,7 @@ contract UnstoppableChallenge is Test {
      * CHECKS SUCCESS CONDITIONS - DO NOT TOUCH
      */
     function _isSolved() private {
-       // Trivial solution: player advanced time beyond the vault's grace period
+       // The grace period must not have elapsed
        assertLt(block.timestamp, vault.end(), "Vault's grace period has ended");
 
         // Flashloan check must fail


### PR DESCRIPTION
## Description

There is a trivial "solution" to pass the test: just advance time to where the grace period is over. At this time the Monitor, which expects only there to be no fee, will fail its flash loan, and the test passes.

So when checking the solution, also check that the time stamp has not advanced beyond the end of the grace period.
