### PR TITLE
Side Entrance: Fix basic functionality

### DIFF
--- a/src/side-entrance/SideEntranceLenderPool.sol
+++ b/src/side-entrance/SideEntranceLenderPool.sol
@@ -41,4 +41,8 @@ contract SideEntranceLenderPool {
             revert RepayFailed();
         }
     }
+
+    receive() external payable {
+        // Allow the contract to receive Ether
+    }
 }

--- a/test/side-entrance/SideEntrance.t.sol
+++ b/test/side-entrance/SideEntrance.t.sol
@@ -46,7 +46,7 @@ contract SideEntranceChallenge is Test {
     * USED FOR TESTING INITIAL STATE - DO NOT TOUCH
     */
     function execute() external payable {
-        (address(pool)).call{value: msg.value}("");
+        payable(pool).transfer(msg.value);
     }
 
     /**

--- a/test/side-entrance/SideEntrance.t.sol
+++ b/test/side-entrance/SideEntrance.t.sol
@@ -36,9 +36,17 @@ contract SideEntranceChallenge is Test {
     /**
      * VALIDATES INITIAL CONDITIONS - DO NOT TOUCH
      */
-    function test_assertInitialState() public view {
+    function test_assertInitialState() public {
         assertEq(address(pool).balance, ETHER_IN_POOL);
         assertEq(player.balance, PLAYER_INITIAL_ETH_BALANCE);
+        pool.flashLoan(ETHER_IN_POOL);
+    }
+    
+    /**
+    * USED FOR TESTING INITIAL STATE - DO NOT TOUCH
+    */
+    function execute() external payable {
+        (address(pool)).call{value: msg.value}("");
     }
 
     /**


### PR DESCRIPTION
As it stands, the pool cannot accept funds in return the normal way (via call/transfer) so there is no way to execute a normal flash loan. This hurts realisim and give a big hint for the solution, as there is only one payable function in the contract.

This adds a `receive()` function to the pool and tests it during the initial tests.