### PR TITLE
Fixed exercises with a maximum number of transaction requirement

### DIFF
--- a/test/backdoor/Backdoor.t.sol
+++ b/test/backdoor/Backdoor.t.sol
@@ -22,9 +22,9 @@ contract BackdoorChallenge is Test {
     WalletRegistry walletRegistry;
 
     modifier checkSolvedByPlayer() {
-        vm.startPrank(player, player);
+        vm.startBroadcast(player);
         _;
-        vm.stopPrank();
+        vm.stopBroadcast();
         _isSolved();
     }
 

--- a/test/naive-receiver/NaiveReceiver.t.sol
+++ b/test/naive-receiver/NaiveReceiver.t.sol
@@ -22,9 +22,9 @@ contract NaiveReceiverChallenge is Test {
     BasicForwarder forwarder;
 
     modifier checkSolvedByPlayer() {
-        vm.startPrank(player, player);
+        vm.startBroadcast(player);
         _;
-        vm.stopPrank();
+        vm.stopBroadcast();
         _isSolved();
     }
 

--- a/test/puppet/Puppet.t.sol
+++ b/test/puppet/Puppet.t.sol
@@ -26,9 +26,9 @@ contract PuppetChallenge is Test {
     IUniswapV1Factory uniswapV1Factory;
 
     modifier checkSolvedByPlayer() {
-        vm.startPrank(player, player);
+        vm.startBroadcast(player);
         _;
-        vm.stopPrank();
+        vm.stopBroadcast();
         _isSolved();
     }
 

--- a/test/shards/Shards.t.sol
+++ b/test/shards/Shards.t.sol
@@ -37,9 +37,9 @@ contract ShardsChallenge is Test {
     uint256 initialTokensInMarketplace;
 
     modifier checkSolvedByPlayer() {
-        vm.startPrank(player, player);
+        vm.startBroadcast(player);
         _;
-        vm.stopPrank();
+        vm.stopBroadcast();
         _isSolved();
     }
 

--- a/test/wallet-mining/WalletMining.t.sol
+++ b/test/wallet-mining/WalletMining.t.sol
@@ -45,9 +45,9 @@ contract WalletMiningChallenge is Test {
     uint256 initialWalletDeployerTokenBalance;
 
     modifier checkSolvedByPlayer() {
-        vm.startPrank(player, player);
+        vm.startBroadcast(player);
         _;
-        vm.stopPrank();
+        vm.stopBroadcast();
         _isSolved();
     }
 


### PR DESCRIPTION
Some challenges enforce a **maximum number of transactions**, which is tracked using Foundry's `vm.getNonce`.

While the current approach uses `vm.startPrank` to simulate player transactions, this method only sets `msg.sender` and `tx.origin` — it **does not increment the sender's nonce for each transaction** (except for contract creations). As a result, nonce-based checks are not effective in counting regular transactions.

Foundry provides `vm.startBroadcast`, which is specifically designed to simulate real transactions that **do increment the nonce**. This pull request replaces `vm.startPrank` with `vm.startBroadcast` (only for the selected challenges) to more accurately enforce transaction count limits.